### PR TITLE
Install latest versions, don't skip everything

### DIFF
--- a/lib/Dist/Zilla/Plugin/TravisCI.pm
+++ b/lib/Dist/Zilla/Plugin/TravisCI.pm
@@ -94,9 +94,9 @@ sub build_travis_yml {
 
 	unless (@{$phases_commands{install}}) {
 		push @{$phases_commands{install}}, (
-			"cpanm ".$verbose." --notest --skip-satisfied Dist::Zilla",
-			"dzil authordeps | grep -ve '^\\W' | xargs -n 5 -P 10 cpanm ".$verbose." ".($self->test_authordeps ? "" : " --notest ")." --skip-satisfied",
-			"dzil listdeps | grep -ve '^\\W' | cpanm ".$verbose." ".($self->test_deps ? "" : " --notest ")." --skip-satisfied",
+			"cpanm ".$verbose." --notest --skip-installed Dist::Zilla",
+			"dzil authordeps | grep -ve '^\\W' | xargs -n 5 -P 10 cpanm ".$verbose." ".($self->test_authordeps ? "" : " --notest ")." --skip-installed",
+			"dzil listdeps | grep -ve '^\\W' | cpanm ".$verbose." ".($self->test_deps ? "" : " --notest ")." --skip-installed",
 		);
 		if (@extra_deps) {
 			push @{$phases_commands{install}}, (
@@ -113,7 +113,7 @@ sub build_travis_yml {
 
 	unless (@{$phases_commands{install}}) {
 		$phases_commands{install} = [
-			'cpanm --installdeps '.$verbose.' '.($self->test_deps ? "" : "--notest").' --skip-satisfied .',
+			'cpanm --installdeps '.$verbose.' '.($self->test_deps ? "" : "--notest").' --skip-installed .',
 		];
 	}
 


### PR DESCRIPTION
cpanm --skip-satisfied Some::Thing skips anything which is already
installed, regardless of the version. --skip-installed checks for
the latest version on CPAN.
