### PR TITLE
Use latest YAML and QuoteNumericStrings feature.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ install:
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed
 language: perl
 perl:
-  - 5.20
-  - 5.18
-  - 5.16
-  - 5.14
-  - 5.12
-  - 5.10
+  - '5.20'
+  - '5.18'
+  - '5.16'
+  - '5.14'
+  - '5.12'
+  - '5.10'
 script:
   - dzil smoke --release --author

--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,6 @@ copyright_year   = 2013
 
 [Prereqs]
 Dist::Zilla = 4.300034
-YAML = 0.84
+YAML = 1.14 ; QuoteNumericStrings
 Path::Class = 0.32
 File::Slurp = 9999.19

--- a/lib/Dist/Zilla/Plugin/TravisCI.pm
+++ b/lib/Dist/Zilla/Plugin/TravisCI.pm
@@ -50,6 +50,7 @@ sub gather_files {
     code_return_type  => 'text',        # YAML::Dump returns text
     code              => sub {
       my $structure = $self->build_travis_yml;
+      local $YAML::QuoteNumericStrings=1;
       return YAML::Dump($structure);
     },
   );
@@ -61,7 +62,8 @@ sub after_build {
   my $self = shift;
   return unless grep { $_ eq 'root' } @{ $self->write_to };
   require YAML;
-  YAML::DumpFile(path($self->zilla->root,'.travis.yml')->stringify,  $self->build_travis_yml );
+  local $YAML::QuoteNumericStrings=1;
+  YAML::DumpFile(path($self->zilla->root,'.travis.yml')->stringify, $self->build_travis_yml);
   return;
 }
 


### PR DESCRIPTION
This is to ensure that strings that resemble numeric keys are encoded
quoted as strings such that decoders correctly decode them as strings,
not numbers.

Thus, trailing 0's ( which are significant ) are not lost,
and there's no subsequent

  Perl: 5.1
  Perl: 5.2

Craziness in your travis smoke list.

( Which are perls version 5.10 and 5.20 respectively )