### PR TITLE
A bunch of test changes and a script modifier feature

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,3 +13,11 @@ copyright_year   = 2013
 [Prereqs]
 Dist::Zilla = 4.300034
 YAML = 1.14 ; QuoteNumericStrings
+
+[Prereqs / tests]
+-phase = test
+-relationship = requires
+Test::DZil = 0
+Path::Tiny = 0.012 ; Ensure paths exist
+Test::TempDir::Tiny = 0
+Test::More = 0

--- a/dist.ini
+++ b/dist.ini
@@ -13,5 +13,3 @@ copyright_year   = 2013
 [Prereqs]
 Dist::Zilla = 4.300034
 YAML = 1.14 ; QuoteNumericStrings
-Path::Class = 0.32
-File::Slurp = 9999.19

--- a/t/basics.t
+++ b/t/basics.t
@@ -1,0 +1,65 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+# ABSTRACT: Test basic functionality
+
+use Test::DZil qw( simple_ini );
+use lib 't/lib';
+use tester;
+
+sub fatal(&) {
+    local $@;
+    my $ok = eval { $_[0]->(); 1 };
+    ( $ok, $@ );
+}
+
+my $test_1 = tester->new();
+
+SKIP: {
+    note "Generating Initial Yaml File";
+    $test_1->add(
+        'dist.ini' => simple_ini(
+            [ 'GatherDir' => { include_dotfiles => 1 }, ],
+            [ 'TravisCI'  => {}, ],
+        )
+    );
+
+    my ( $ok, $error ) = fatal { $test_1->builder->build };
+    ok( $ok, "Build OK" ) or do {
+        diag explain $error;
+        skip "Build did not pass", 3;
+    };
+
+    my $gen_yaml = $test_1->sourcedir->child('.travis.yml');
+
+    ok( $gen_yaml->exists, '.travis.yml added' );
+    ok( !$test_1->builddir->child('.travis.yml')->exists,
+        '.travis.yml not added to build dir' );
+    cmp_ok( [ $gen_yaml->lines_utf8( { chomp => 1 } ) ]->[0],
+        qw[eq], '---', 'Looks like a valid YAML file' );
+}
+
+my $test_2 = tester->new( tempdir => $test_1->sourcedir );
+
+SKIP: {
+    note "Simulated rebuild on a dir with exisiting .yml file";
+
+    my ( $ok, $error ) = fatal { $test_2->builder->build };
+    ok( $ok, "Build OK" ) or do {
+        diag explain $error;
+        skip "Build did not pass", 3;
+    };
+
+    my $gen_yaml = $test_2->sourcedir->child('.travis.yml');
+    ok( $gen_yaml->exists, '.travis.yml in second generation' );
+    ok( $test_2->builddir->child('.travis.yml')->exists,
+            '.travis.yml in second generation build dir '
+          . '( due to gatherdir + dotfiles )' );
+
+    cmp_ok( [ $gen_yaml->lines_utf8( { chomp => 1 } ) ]->[0],
+        qw[eq], '---', 'Looks like a valid YAML file' );
+}
+done_testing;
+

--- a/t/lib/tester.pm
+++ b/t/lib/tester.pm
@@ -1,0 +1,61 @@
+use 5.006;    # our
+use strict;
+use warnings;
+
+package tester;
+
+# ABSTRACT: minitester thing for TravisCI
+
+use Test::DZil qw( Builder );
+use Path::Tiny qw( path );
+use Test::TempDir::Tiny qw();
+use Test::More import => [qw( note explain )];
+
+# ->new( %opts ) => Object
+# ->new( { opts } ) => Object
+sub new { return bless { ref $_[1] ? %{ $_[1] } : splice @_, 1 }, $_[0] }
+
+# ->tempdir() => Temp Path String
+sub tempdir {
+    return $_[0]->{tempdir} if exists $_[0]->{tempdir};
+    return ( $_[0]->{tempdir} =
+          Test::TempDir::Tiny::tempdir( $_[0]->{name} ? $_[0]->{name} : () ) );
+}
+
+# ->add( $path, $text_content )
+sub add {
+    path( $_[0]->tempdir, $_[1] )->parent->mkpath;
+    path( $_[0]->tempdir, $_[1] )->spew_utf8( $_[2] );
+}
+
+# ->builder() => Builder Object
+sub builder {
+    my $self = shift;
+    return $self->{builder} if exists $self->{builder};
+    $self->{builder} =
+      Builder->from_config( { dist_root => q[] . $self->tempdir, @_ } );
+    $self->{builder}->chrome->logger->set_debug(1);
+    $self->{builder};
+}
+
+# ->builddir() => Path Object
+sub builddir {
+    return path( $_[0]->builder->tempdir, 'build' );
+}
+
+# ->sourcedir() => Path Object
+sub sourcedir {
+    return path( $_[0]->builder->tempdir, 'source' );
+}
+
+# ->auto_note_stuff()
+sub auto_note_stuff {
+    note explain $_[0]->builder->log_events;
+    note explain $_[0]->builder->distmeta;
+    note $_ for $_[0]->sourcedir->children();
+    note $_ for $_[0]->builddir->children();
+
+}
+
+1;
+

--- a/t/modifier_script.t
+++ b/t/modifier_script.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+# ABSTRACT: Test augmentation via a script
+
+use Test::DZil qw( simple_ini );
+use lib 't/lib';
+use tester;
+use YAML qw();
+
+sub fatal(&) {
+    local $@;
+    my $ok = eval { $_[0]->(); 1 };
+    ( $ok, $@ );
+}
+
+SKIP: {
+    my $test_1 = tester->new();
+    $test_1->add(
+        'dist.ini' => simple_ini(
+            [ 'GatherDir' => { include_dotfiles => 1 }, ],
+            [
+                'TravisCI' =>
+                  { 'modifier_script' => 'travisci_customizations.pl' },
+            ],
+        )
+    );
+    $test_1->add( 'travisci_customizations.pl' => <<'EOF');
+use strict;
+use warnings;
+sub {
+  my ( $code ) = @_;
+  $code->{'this_key_is_bogus'} = 'a value';
+};
+EOF
+
+    my ( $ok, $error ) = fatal { $test_1->builder->build };
+    ok( $ok, "Build OK" ) or do {
+        diag explain $error;
+        skip "Build did not pass", 3;
+    };
+
+    my $gen_yaml = $test_1->sourcedir->child('.travis.yml');
+
+    ok( $gen_yaml->exists, '.travis.yml added' );
+
+    my $content = YAML::Load( $gen_yaml->slurp_utf8 );
+    ok( exists $content->{this_key_is_bogus}, 'Modified key emitted' );
+    cmp_ok( $content->{this_key_is_bogus},
+        'eq', 'a value', 'Modified key has expected value' );
+}
+
+done_testing;
+

--- a/t/subclass.t
+++ b/t/subclass.t
@@ -1,0 +1,58 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+# ABSTRACT: Test subclassing the plugin
+
+use Test::DZil qw( simple_ini );
+use lib 't/lib';
+use tester;
+use YAML qw();
+
+sub fatal(&) {
+    local $@;
+    my $ok = eval { $_[0]->(); 1 };
+    ( $ok, $@ );
+}
+
+{
+
+    package T::Plugin;
+    use Moose;
+    extends 'Dist::Zilla::Plugin::TravisCI';
+
+    sub modify_travis_yml {
+        my ( $self, %config ) = @_;
+        $config{this_key_is_bogus} = 'a value';
+        return %config;
+    }
+}
+
+SKIP: {
+    my $test_1 = tester->new();
+    $test_1->add(
+        'dist.ini' => simple_ini(
+            [ 'GatherDir'  => { include_dotfiles => 1 }, ],
+            [ '=T::Plugin' => {}, ],
+        )
+    );
+
+    my ( $ok, $error ) = fatal { $test_1->builder->build };
+    ok( $ok, "Build OK" ) or do {
+        diag explain $error;
+        skip "Build did not pass", 3;
+    };
+
+    my $gen_yaml = $test_1->sourcedir->child('.travis.yml');
+
+    ok( $gen_yaml->exists, '.travis.yml added' );
+
+    my $content = YAML::Load( $gen_yaml->slurp_utf8 );
+    ok( exists $content->{this_key_is_bogus}, 'Modified key emitted' );
+    cmp_ok( $content->{this_key_is_bogus},
+        'eq', 'a value', 'Modified key has expected value' );
+}
+
+done_testing;
+


### PR DESCRIPTION
Most of these commits are simply adding basic tests for existing functionality.

The final commit adds a new "modifier_script" attribute that:

- If not set, is ignored
- If is set, is checked, and if missing, ignored.
- If is set, is checked, and if present, attempted to evaluate in a similar manner to "modify_travis_yml".

As to how the users sub is called and returned I'm not 100% sure of it.

I *like* being able to just tweak the hashref in place from the sub without passing it around.
But I also like that it may be useful to throw a new hashref out and doing it that way would be ugly.

So it kinda supports doing it both ways ... But Mmmh.  The rest of the shit is solid, that's the only part I'm (???) about.