### PR TITLE
Remove unneeded deps on Path::Class and File::Slurp

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,5 +13,3 @@ copyright_year   = 2013
 [Prereqs]
 Dist::Zilla = 4.300034
 YAML = 1.14 ; QuoteNumericStrings
-Path::Class = 0.32
-File::Slurp = 9999.19


### PR DESCRIPTION
These needlessly complicate/confuse installation, because File::Slurp randomly fails installation w/ parallel testing.