### PR TITLE
Add support for the apt_packages Travis addon

### DIFF
--- a/lib/Dist/Zilla/Plugin/TravisCI.pm
+++ b/lib/Dist/Zilla/Plugin/TravisCI.pm
@@ -8,7 +8,7 @@ use Dist::Zilla::File::FromCode;
 with 'Dist::Zilla::Role::FileGatherer','Dist::Zilla::Role::AfterBuild';
 
 our @phases = ( ( map { my $phase = $_; ('before_'.$phase, $phase, 'after_'.$phase) } qw( install script ) ), 'after_success', 'after_failure' );
-our @emptymvarrayattr = qw( notify_email notify_irc requires env script_env extra_dep );
+our @emptymvarrayattr = qw( notify_email notify_irc requires env script_env extra_dep apt_package );
 
 has $_ => ( is => 'ro', isa => 'ArrayRef[Str]', default => sub { [] } ) for (@phases, @emptymvarrayattr);
 
@@ -91,6 +91,14 @@ sub build_travis_yml {
 
 	if (%notifications) {
 		$travisyml{notifications} = \%notifications;
+	}
+
+	my %addons;
+	if (@{$self->apt_package()}) {
+		$addons{apt_packages} = $self->apt_package();
+	}
+	if (%addons) {
+		$travisyml{addons} = \%addons;
 	}
 
 	my %phases_commands = map { $_ => $self->$_ } @phases;
@@ -210,6 +218,7 @@ __PACKAGE__->meta->make_immutable;
   test_authordeps = 0
   no_notify_email = 0
   coveralls = 0
+  apt_package = libzmq1-dev
 
 =head1 DESCRIPTION
 

--- a/t/apt_package.t
+++ b/t/apt_package.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::DZil;
+use YAML;
+
+subtest 'apt_package option' => sub {
+	my $packages = [ 'libzmq-dev' ];
+	my $tzil = create_tzil({
+		apt_package => $packages,
+	});
+	$tzil->build();
+	my $travis_yml = YAML::Load($tzil->slurp_file('source/.travis.yml'));
+	is_deeply(
+		$travis_yml->{addons},
+		{ apt_packages => $packages },
+		'addons.apt_packages configured with package'
+	);
+
+	push @{$packages}, 'libzmq1';
+	$tzil = create_tzil({
+		apt_package => $packages,
+	});
+	$tzil->build();
+	$travis_yml = YAML::Load($tzil->slurp_file('source/.travis.yml'));
+	is_deeply(
+		$travis_yml->{addons},
+		{ apt_packages => $packages },
+		'addons.apt_packages configured with both packages'
+	);
+};
+
+sub create_tzil {
+	my ($travis_ci_config) = @_;
+	return Builder->from_config(
+		{ dist_root => 't/corpus' },
+		{
+			add_files => {
+				'source/dist.ini' => simple_ini([
+					TravisCI => $travis_ci_config,
+				])
+			}
+		}
+	);
+}
+
+done_testing;


### PR DESCRIPTION
The newer, [container-based](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) infrastructure does not allow the use of `sudo`, so the only way to install additional dependencies is to use the [`apt_packages` addon](http://docs.travis-ci.com/user/apt-packages/) (which works in VM-based builds, too). The attached patches add support for this addon to the plugin.
