### PR TITLE
Add Beam::Event/Emitter support  via a modify_travis_yml event.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,10 +10,18 @@ copyright_year   = 2013
 
 [@Author::GETTY]
 
+; Because bootstrap...
+; authordep Beam::Event
+; authordep Beam::Emitter
 [Prereqs]
 Dist::Zilla = 4.300034
 YAML = 1.14 ; QuoteNumericStrings
+Beam::Event = 0
+Beam::Emitter = 0
 
+; For xt/ tests
+; authordep Beam::Wire
+; authordep  Dist::Zilla::Plugin::Beam::Connector
 [Prereqs / tests]
 -phase = test
 -relationship = requires

--- a/lib/Dist/Zilla/Plugin/TravisCI.pm
+++ b/lib/Dist/Zilla/Plugin/TravisCI.pm
@@ -5,7 +5,7 @@ use Moose;
 use Path::Tiny qw( path );
 use Dist::Zilla::File::FromCode;
 
-with 'Dist::Zilla::Role::FileGatherer','Dist::Zilla::Role::AfterBuild';
+with 'Dist::Zilla::Role::FileGatherer','Dist::Zilla::Role::AfterBuild', 'Beam::Emitter';
 
 our @phases = ( ( map { my $phase = $_; ('before_'.$phase, $phase, 'after_'.$phase) } qw( install script ) ), 'after_success', 'after_failure' );
 our @emptymvarrayattr = qw( notify_email notify_irc requires env script_env extra_dep );
@@ -171,8 +171,11 @@ sub build_travis_yml {
 		}
 	}
 
-  %travisyml = $self->modify_travis_yml(%travisyml);
-  return \%travisyml;
+  return $self->emit(
+    'modify_travis_yml',
+    class      => 'Dist::Zilla::Event::TravisCI::YML',
+    travis_yml => { $self->modify_travis_yml(%travisyml) }
+  )->travis_yml;
 }
 
 sub modify_travis_yml {
@@ -182,8 +185,17 @@ sub modify_travis_yml {
 
 __PACKAGE__->meta->make_immutable;
 
-1;
+package    # Hidden
+  Dist::Zilla::Event::TravisCI::YML;
 
+use Moose;
+extends 'Beam::Event';
+
+has 'travis_yml' => ( is => 'rw', isa => 'HashRef', required => 1 );
+
+__PACKAGE__->meta->make_immutable;
+
+1;
 
 =head1 SYNOPSIS
 
@@ -221,6 +233,34 @@ documentation :).
 =head1 BASED ON
 
 This plugin is based on code of L<Dist::Zilla::TravisCI>.
+
+=head1 EVENTS
+
+This module provides an event to allow modifying the C<travis_yml> data structure
+prior to writing it to file.
+
+=head2 C<modify_travis_yml>
+
+This event can be hooked with L<< C<[Beam::Connector]>|Dist::Zilla::Plugin::Beam::Connector >>
+in order to allow 3rd party plugins to modify the C<YAML> data.
+
+
+  ; Hook into another plugin from this
+  on = plugin:TravisCI#modify_travis_yml => plugin:AuthorTweaks#tweak_travis
+
+  ; Hook into an arbitrary class loaded by Beam
+  container = inc/beam.yml
+  on = plugin:TravisCI#modify_travis_yml => container:disttweaks#tweak_travis
+
+The recieving method(s) will recieve a C<Dist::Zilla::Event::TravisCI::YML> event to modify
+directly.
+
+  sub event_hander {
+    my ( $self , $event ) = @_;
+    push @{ $event->travis_yml->{env} }, 'AUTHOR_TESTING=1';
+  }
+
+B<< See L<< C<[Beam::Connector]>|Dist::Zilla::Plugin::Beam::Connector/Receiving Events >> for details. >>
 
 =head1 SUPPORT
 

--- a/xt/release/beam.t
+++ b/xt/release/beam.t
@@ -1,0 +1,93 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Requires (
+  {
+    'Dist::Zilla::Plugin::Beam::Connector' => 0,
+    'Beam::Wire'                           => 0,
+  }
+);
+
+use Test::DZil qw( Builder simple_ini );
+
+# ABSTRACT: Ensure BEAM API does what it says it does.
+
+my @seen_events;
+
+# This definition could live on CPAN, or in @INC (like in inc/ ), it doesn't matter really.
+{
+
+  package    # hide me?
+    My::Event::Munger;
+
+  sub new { bless { @_[ 1 .. $#_ ] }, $_[0] }
+
+  sub handle_event {
+    my ( $self, $event ) = @_;
+    push @seen_events, [ $event, $self ];
+    push @{ $event->travis_yml->{env} }, @{ $self->{env} || [] };
+  }
+  BEGIN { $INC{'My/Event/Munger.pm'} = 1 }
+}
+
+# This is a bit of a contrived example, just to emulate the fact multiple plugin instances
+# can hook into the same event bus, and to demonstrate individual instance configuration
+my $container = <<'EOCONTAINER';
+---
+my_munger:
+  $class: My::Event::Munger
+  env:
+    - AUTHOR_TESTING=1
+    - RELEASE_TESTING=1
+
+my_other_munger:
+  $class: My::Event::Munger
+  env:
+    - SMOKE_TESTING=1
+
+EOCONTAINER
+
+my $ini = simple_ini(
+  ['TravisCI'],
+  [
+    'Beam::Connector' => {
+      container => 'beam.yml',
+      on        => [
+
+        # Order of these on statements affect output order
+        'plugin:TravisCI#modify_travis_yml => container:my_munger#handle_event',
+        'plugin:TravisCI#modify_travis_yml => container:my_other_munger#handle_event',
+      ],
+    }
+  ]
+);
+use Path::Tiny qw(path);
+my $tzil = Builder->from_config(
+  { dist_root => 'invalid' },
+  {
+    add_files => {
+      path(qw( source dist.ini ))   => $ini,
+      path(qw( source beam.yml ))   => $container,
+      path(qw( source lib Foo.pm )) => 'package Foo',
+    },
+  }
+);
+
+$tzil->chrome->logger->set_debug(1);
+$tzil->build;
+
+pass("built ok");
+
+my $need_diag = 0;
+
+$need_diag = 1 unless is( scalar @seen_events, 2, "Saw 2 discrete events" );
+my $final_yml = $seen_events[-1]->[0]->travis_yml;
+$need_diag = 1 unless is( scalar @{ $final_yml->{env} }, 3, "All 3 lines added" );
+$need_diag = 1
+  unless is_deeply( $final_yml->{env}, [ 'AUTHOR_TESTING=1', 'RELEASE_TESTING=1', 'SMOKE_TESTING=1' ], "Structure is expected" );
+
+note explain $final_yml if $need_diag;
+
+done_testing;
+


### PR DESCRIPTION
A basic example is available in the "beam" release test.

B<Note: > This does not add any dependency on Dist::Zilla::Plugin::Beam::Connector, and that is by design. No knowledge of the connector-ware is needed inside either the sender or receiver. 